### PR TITLE
fix: CI API Key 파싱 오류 수정 (invalid curve name)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,35 @@
 default_platform(:ios)
 
+API_KEY_PATH = "/tmp/AuthKey.p8"
+
 platform :ios do
   before_all do
     setup_ci if ENV["CI"]
+
+    if ENV["CI"] && ENV["APP_STORE_CONNECT_API_KEY_CONTENT"]
+      require "base64"
+      File.write(API_KEY_PATH, Base64.decode64(ENV["APP_STORE_CONNECT_API_KEY_CONTENT"]))
+    end
+  end
+
+  def api_key
+    if ENV["CI"]
+      app_store_connect_api_key(
+        key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+        issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+        key_filepath: API_KEY_PATH,
+        in_house: false
+      )
+    else
+      require "json"
+      key_data = JSON.parse(File.read(File.expand_path("../api_key.json", __FILE__)))
+      app_store_connect_api_key(
+        key_id: key_data["key_id"],
+        issuer_id: key_data["issuer_id"],
+        key_content: key_data["key"],
+        in_house: false
+      )
+    end
   end
 
   desc "Run unit tests"
@@ -18,14 +45,6 @@ platform :ios do
 
   desc "Build and upload to TestFlight (internal testers)"
   lane :beta_internal do
-    api_key = app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
-      key_content: ENV["APP_STORE_CONNECT_API_KEY_CONTENT"],
-      is_key_content_base64: true,
-      in_house: false
-    )
-
     match(
       type: "appstore",
       api_key: api_key,
@@ -50,14 +69,6 @@ platform :ios do
 
   desc "Build and upload to TestFlight (external testers)"
   lane :beta_external do
-    api_key = app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
-      key_content: ENV["APP_STORE_CONNECT_API_KEY_CONTENT"],
-      is_key_content_base64: true,
-      in_house: false
-    )
-
     match(
       type: "appstore",
       api_key: api_key,
@@ -82,14 +93,6 @@ platform :ios do
 
   desc "Build and submit to App Store"
   lane :release do
-    api_key = app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
-      key_content: ENV["APP_STORE_CONNECT_API_KEY_CONTENT"],
-      is_key_content_base64: true,
-      in_house: false
-    )
-
     match(
       type: "appstore",
       api_key: api_key,


### PR DESCRIPTION
## Problem
`app_store_connect_api_key`에 base64 인코딩된 키 내용을 직접 전달할 때 OpenSSL이 EC 키를 파싱하지 못하는 오류 발생

```
invalid curve name
💥 app_store_connect_api_key
```

## Solution
- CI 환경에서 base64 Secret을 `.p8` 파일로 디코딩 후 `key_filepath`로 전달하는 방식으로 변경
- 로컬 환경에서는 `fastlane/api_key.json`에서 key content를 읽어 처리

## Changes
- `fastlane/Fastfile`: `before_all`에서 base64 디코딩 후 `/tmp/AuthKey.p8`로 저장
- CI/로컬 환경 분기 처리 (`ENV["CI"]` 체크)

## Test plan
- [ ] `develop` push 후 TestFlight 내부 배포 워크플로우 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)